### PR TITLE
Add Terse()

### DIFF
--- a/lib/Data/Dump/Streamer.pm
+++ b/lib/Data/Dump/Streamer.pm
@@ -2120,15 +2120,6 @@ sub Out {
 }
 
 
-sub print_token {
-    my ($self, $str)=@_;
-    $self->{fh}->print($str);
-}
-sub print_quoted {
-    my ( $self, $str )=@_;
-    $self->{fh}->print($str);
-}
-
 # sqz(str,begin,end)
 sub sqz {
     require Compress::Zlib;

--- a/lib/Data/Dump/Streamer.pm
+++ b/lib/Data/Dump/Streamer.pm
@@ -756,6 +756,8 @@ sub new {
 
             purity       => 1,         # test
 
+            terse        => 0,
+
             # use this if deparse is 0
             codestub     => 'sub { Carp::confess "Dumped code stub!" }',
             formatstub   => 'do{ local *F; eval "format F =\nFormat Stub\n.\n"; *F{FORMAT} }',
@@ -1924,7 +1926,7 @@ sub _dump_apply_fix { #handle fix statements and GLOB's here.
                     next;
                 }
 
-                $self->{fh}->print("$name = ");
+                $self->{fh}->print("$name = ") unless $self->{style}{terse};
                 my $ret=$self->_dump_sv(*$lhs{$t},$depth,\$dumped,$name,length($name)+3);
                 Carp::confess "\nUnhandled alias value '$ret' returned to _dump_apply_fix()!"
                     if $ret;
@@ -2272,7 +2274,7 @@ sub _dump_sv {
         }
         #push @{$self->{out_names}},$name; #must
         #push @{$self->{declare}},$name;
-        unless ($name=~/^\&/) { # XXX
+        unless ($self->{style}{terse} || $name=~/^\&/) { # XXX
             my $str=(($self->{style}{declare} && $name!~/^\*/
                      && !$self->{lexicals}{added}{$name}
                      ) ? "my$optspace" : ""
@@ -2310,7 +2312,7 @@ sub _dump_sv {
             $self->{buf}+=5;
         } else {
             my $is_ro=($self->{style}{ro} && $ro && !$is_ref);
-            if ($is_ro and !$self->{style}{purity}) {
+            if ($is_ro and !$self->{style}{purity} and !$self->{style}{terse}) {
                 $self->{fh}->print("make_ro($optspace");
             }
             if ($glob) {
@@ -2351,10 +2353,12 @@ sub _dump_sv {
                 $self->{buf}=length($1) if $quoted=~/\n([^\n]*)\s*\z/;
                 $self->{fh}->print($quoted); #;
             }
-            if ($is_ro && $self->{style}{purity}) {
-                $self->_add_fix('sub call','make_ro',$name);
-            } elsif ($is_ro) {
-                $self->{fh}->print("$optspace)");
+            if( !$self->{style}{terse} ) {
+                if ($is_ro && $self->{style}{purity}) {
+                    $self->_add_fix('sub call','make_ro',$name);
+                } elsif ($is_ro) {
+                    $self->{fh}->print("$optspace)");
+                }
             }
             #return
         }
@@ -3051,6 +3055,8 @@ or undef. In void context with no arguments the names are cleared.
 B<NOTE:>
 Must be called before C<Data()> is called.
 
+If you wish to have no names, use L<Terse>.
+
 =cut
 
 sub Names {
@@ -3076,6 +3082,30 @@ sub Names {
 
     return wantarray ? @{$self->{unames}||[]} : $self->{unames}
 }
+
+=item Terse
+
+=item Terse BOOL
+
+When true, no variable names will be created.  Data will be dumped as
+anonymous references or values.
+
+    Dump([])->Out;              # $ARRAY1 = []
+    Dump([])->Terse(1)->Out;    # []
+
+=cut
+
+sub Terse {
+    my $self = shift->_safe_self;
+    if( @_ ) {
+        $self->{style}{terse} = shift;
+        return $self;
+    }
+    else {
+        return $self->{style}{terse};
+    }
+}
+
 
 =for UEDIT
 sub Purity {}

--- a/t/terse.t
+++ b/t/terse.t
@@ -1,0 +1,23 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use Data::Dump::Streamer;
+
+note "Single variable with Terse"; {
+    is_deeply( eval(Dump([])->Terse(1)->Out), [] );
+    is_deeply eval(Dump({})->Terse(1)->Out), {};
+    is        eval(Dump(23)->Terse(1)->Out), 23;
+    is_deeply eval(Dump({ foo => 23 })->Terse(1)->Out), { foo => 23 };
+}
+
+note "Many variables with Terse";
+
+note "Code refs with Terse"; {
+    is eval(Dump(sub { 23 })->Terse(1)->Out)->(), 23;
+}
+
+done_testing;


### PR DESCRIPTION
This adds Terse(), like in Data::Dumper, to disable the "$VAR = " part of the dump.  This makes DDS more flexible to serialize and deserialize data structures.

I'm quite sure there's a ton of special cases I missed.
