### PR TITLE
normalise \\undef dumping for perl <5.20

### DIFF
--- a/t/test_helper.pl
+++ b/t/test_helper.pl
@@ -183,6 +183,8 @@ sub normalize {
         s/\(0x[0-9a-fA-F]+\)/(0xdeadbeef)/g;
         s/\r\n/\n/g;
         s/\s+$//gm;
+        s{\\\\undef}{\\do { my \$v = \\do { my \$v = undef } }}g
+            if $] < 5.020;
         $_.="\n";
 
         #warn "<after>\n$_</after>\n";


### PR DESCRIPTION
With this simple change, all tests pass on old and new perls. Tested on 5.20.0, 5.18.2, 5.16.3, 5.14.4, 5.12.5, 5.8.9
