### PR TITLE
Fix tests for Perl 5.26

### DIFF
--- a/t/dogpound.t
+++ b/t/dogpound.t
@@ -8,8 +8,7 @@ use warnings;
 use Data::Dumper;
 
 # imports same()
-(my $helper=$0)=~s/\w+\.\w+$/test_helper.pl/;
-require $helper;
+require "./t/test_helper.pl";
 # use this one for simple, non evalable tests. (GLOB)
 #   same ( $got,$expected,$name,$obj )
 #

--- a/t/dump.t
+++ b/t/dump.t
@@ -7,8 +7,7 @@ use Data::Dumper;
 #$Id: dump.t 40 2007-12-22 00:37:55Z demerphq $#
 
 # imports same()
-(my $helper=$0)=~s/\w+\.\w+$/test_helper.pl/;
-require $helper;
+require "./t/test_helper.pl";
 # use this one for simple, non evalable tests. (GLOB)
 #   same ( $got,$expected,$name,$obj )
 #

--- a/t/filter.t
+++ b/t/filter.t
@@ -7,8 +7,7 @@ use Data::Dumper;
 #$Id: filter.t 26 2006-04-16 15:18:52Z demerphq $#
 
 # imports same()
-(my $helper=$0)=~s/\w+\.\w+$/test_helper.pl/;
-require $helper;
+require "./t/test_helper.pl";
 # use this one for simple, non evalable tests. (GLOB)
 #   same ( $got,$expected,$name,$obj )
 #

--- a/t/globtest.t
+++ b/t/globtest.t
@@ -8,8 +8,7 @@ use warnings;
 use Data::Dumper;
 
 # imports same()
-(my $helper=$0)=~s/\w+\.\w+$/test_helper.pl/;
-require $helper;
+require "./t/test_helper.pl";
 # use this one for simple, non evalable tests. (GLOB)
 #   same ( $got,$expected,$name,$obj )
 #

--- a/t/hardrefs.t
+++ b/t/hardrefs.t
@@ -8,8 +8,7 @@ use warnings;
 use Data::Dumper;
 
 # imports same()
-(my $helper=$0)=~s/\w+\.\w+$/test_helper.pl/;
-require $helper;
+require "./t/test_helper.pl";
 # use this one for simple, non evalable tests. (GLOB)
 #   same ( $got,$expected,$name,$obj )
 #

--- a/t/impure_madness.t
+++ b/t/impure_madness.t
@@ -8,8 +8,7 @@ use warnings;
 use Data::Dumper;
 
 # imports same()
-(my $helper=$0)=~s/\w+\.\w+$/test_helper.pl/;
-require $helper;
+require "./t/test_helper.pl";
 # use this one for simple, non evalable tests. (GLOB)
 #   same ( $got,$expected,$name,$obj )
 #

--- a/t/lexicals.t
+++ b/t/lexicals.t
@@ -5,8 +5,7 @@ use warnings;
 
 use Data::Dump::Streamer;
 use Test::More tests => 14;
-(my $helper=$0)=~s/\w+\.\w+$/test_helper.pl/;
-require $helper;
+require "./t/test_helper.pl";
 diag "\nPadWalker ",
     eval "use PadWalker 0.99; 1" ? qq($PadWalker::VERSION is) : "isn't",
     " installed";

--- a/t/locked.t
+++ b/t/locked.t
@@ -9,8 +9,7 @@ use warnings;
 
 
 # imports same()
-(my $helper=$0)=~s/\w+\.\w+$/test_helper.pl/;
-require $helper;
+require "./t/test_helper.pl";
 # use this one for simple, non evalable tests. (GLOB)
 #   same ( $got,$expected,$name,$obj )
 #

--- a/t/madness.t
+++ b/t/madness.t
@@ -7,8 +7,7 @@ use strict;
 use warnings;
 use Data::Dumper;
 # imports same()
-(my $helper=$0)=~s/\w+\.\w+$/test_helper.pl/;
-require $helper;
+require "./t/test_helper.pl";
 # use this one for simple, non evalable tests. (GLOB)
 #   same ( $got,$expected,$name,$obj )
 #

--- a/t/madness_json.t
+++ b/t/madness_json.t
@@ -12,8 +12,7 @@ BEGIN {
 };
 BEGIN { use_ok( 'Data::Dump::Streamer', qw(:undump) ); }
 # imports same()
-(my $helper=$0)=~s/\w+\.\w+$/test_helper.pl/;
-require $helper;
+require "./t/test_helper.pl";
 # use this one for simple, non evalable tests. (GLOB)
 #   same ( $got,$expected,$name,$obj )
 #

--- a/t/madness_w.t
+++ b/t/madness_w.t
@@ -14,8 +14,7 @@ SKIP:{
         unless eval { weaken($_ref) };
 
 # imports same()
-(my $helper=$0)=~s/\w+\.\w+$/test_helper.pl/;
-require $helper;
+require "./t/test_helper.pl";
 # use this one for simple, non evalable tests. (GLOB)
 #   same ( $got,$expected,$name,$obj )
 #

--- a/t/names.t
+++ b/t/names.t
@@ -7,8 +7,7 @@ use Data::Dumper;
 #$Id: names.t 26 2006-04-16 15:18:52Z demerphq $#
 
 # imports same()
-(my $helper=$0)=~s/\w+\.\w+$/test_helper.pl/;
-require $helper;
+require "./t/test_helper.pl";
 # use this one for simple, non evalable tests. (GLOB)
 #   same ( $got,$expected,$name,$obj )
 #

--- a/t/overload.t
+++ b/t/overload.t
@@ -9,8 +9,7 @@ require overload;
 #$Id: overload.t 26 2006-04-16 15:18:52Z demerphq $#
 
 # imports same()
-(my $helper=$0)=~s/\w+\.\w+$/test_helper.pl/;
-require $helper;
+require "./t/test_helper.pl";
 
 sub dump_obj {
     my $obj = shift;

--- a/t/sortkeys.t
+++ b/t/sortkeys.t
@@ -7,8 +7,7 @@ use Data::Dumper;
 #$Id: sortkeys.t 26 2006-04-16 15:18:52Z demerphq $#
 
 # imports same()
-(my $helper=$0)=~s/\w+\.\w+$/test_helper.pl/;
-require $helper;
+require "./t/test_helper.pl";
 # use this one for simple, non evalable tests. (GLOB)
 #   same ( $got,$expected,$name,$obj )
 #

--- a/t/tree.t
+++ b/t/tree.t
@@ -7,8 +7,7 @@ use Data::Dumper;
 #$Id: tree.t 26 2006-04-16 15:18:52Z demerphq $#
 
 # imports same()
-(my $helper=$0)=~s/\w+\.\w+$/test_helper.pl/;
-require $helper;
+require "./t/test_helper.pl";
 # use this one for simple, non evalable tests. (GLOB)
 #   same ( $got,$expected,$name,$obj )
 #


### PR DESCRIPTION
This removes the jiggery-pokery with $0 because its not actually
necessary vendor side, and require './t/test_helper.pl' is *MORE* than
adequate

Bug: https://bugs.gentoo.org/615698
Bug: https://rt.cpan.org/Ticket/Display.html?id=121169